### PR TITLE
Remove useless with-eval-after-load

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,8 +23,7 @@ Install =messages-are-flowing.el= with =M-x package-install-file=, and
 then add the following to your =.emacs= file:
 
 #+BEGIN_SRC emacs-lisp
-(with-eval-after-load "message"
-  (add-hook 'message-mode-hook 'messages-are-flowing-use-and-mark-hard-newlines))
+(add-hook 'message-mode-hook 'messages-are-flowing-use-and-mark-hard-newlines)
 #+END_SRC
 
 


### PR DESCRIPTION
I think `with-eval-after-load` is not necessary here. Even if `message-mode-hook` is not bound yet, you can use `add-hook` on it which will create it. When `message-mode` gets required, the definition of `message-mode-hook` will retain its value.